### PR TITLE
Modifications for MSVC

### DIFF
--- a/c/common/spidriver.c
+++ b/c/common/spidriver.c
@@ -5,8 +5,8 @@
 #include <fcntl.h>
 #if !defined(WIN32)
 #include <sys/ioctl.h>
-#endif
 #include <unistd.h>
+#endif
 #include <errno.h>
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
@@ -18,6 +18,7 @@
 
 #if defined(WIN32)  // {
 
+#define NOMINMAX
 #include <windows.h>
 
 void ErrorExit(const char *func_name) 
@@ -39,8 +40,8 @@ void ErrorExit(const char *func_name)
 
     // Display the error message and exit the process
 
-    char mm[lstrlen((LPCTSTR)lpMsgBuf) + strlen(func_name) + 40];
-    sprintf(mm, "%s failed with error %lu:\n%s", func_name, dw, (char*)lpMsgBuf); 
+    char mm[256];
+    snprintf(mm, sizeof(mm), "%s failed with error %lu:\n%s", func_name, dw, (char*)lpMsgBuf);
     MessageBox(NULL, (LPCTSTR)mm, TEXT("Error"), MB_OK); 
 
     LocalFree(lpMsgBuf);
@@ -54,7 +55,7 @@ HANDLE openSerialPort(const char *portname)
     if (portname[0] == 'C')
         fmt = "\\\\.\\%s";
     else
-        fmt == "%s";
+        fmt = "%s";
     snprintf(fullname, sizeof(fullname), fmt, portname);
     DWORD  accessdirection = GENERIC_READ | GENERIC_WRITE;
     HANDLE hSerial = CreateFile((LPCSTR)fullname,


### PR DESCRIPTION
Changes to the WIN32 part of the code for MSVC (same as in I2CDriver repo):

- added `#define NOMINMAX` macro to prevent windows from clashing with C++ use
- make `mm` array fixed size and changed `sprintf` to `snprintf`
- `#include <unistd.h>` only when not WIN32. MSVC doesn't have it and minGW doesn't need it.
- `==` -> `=` fix