### PR TITLE
gui.py: Fixup to avoid deprecated warnings

### DIFF
--- a/python/samples/gui.py
+++ b/python/samples/gui.py
@@ -9,7 +9,7 @@ import struct
 
 from spidriver import SPIDriver
 
-def ison(button): return button.get_state() == Gtk.StateType.ACTIVE
+def ison(button): return (button.get_state_flags() & Gtk.StateFlags.CHECKED) != 0
 def ishex(s): return re.match("[0-9a-fA-F]{2}$", s) is not None
 
 class SPIDriverWindow(Gtk.Window):

--- a/python/samples/gui.py
+++ b/python/samples/gui.py
@@ -42,13 +42,13 @@ class SPIDriverWindow(Gtk.Window):
             return r
 
         def checkbutton(name, state, click):
-            r = Gtk.CheckButton(name)
+            r = Gtk.CheckButton(label=name)
             r.set_active(state)
             r.connect("clicked", click)
             return r
 
         def button(name, click):
-            r = Gtk.Button(name)
+            r = Gtk.Button(label=name)
             r.connect("clicked", click)
             return r
 


### PR DESCRIPTION
Currently when the `gui.py` sample is run the following warnings are logged to the console:
```
gui.py:51: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  r = Gtk.Button(name)
gui.py:45: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  r = Gtk.CheckButton(name)
```

This PR resolves the warnings by passing the label using Python keyword arguments (as the warning suggests).