### PR TITLE
spicl: improve command arg checking

### DIFF
--- a/c/common/spidriver.c
+++ b/c/common/spidriver.c
@@ -385,6 +385,10 @@ int spi_commands(SPIDriver *sd, int argc, char *argv[])
     case 't':
       {
         token = argv[++i];
+        if (token == NULL) {
+          fprintf(stderr, "Expected values to write\n");
+          return 1;
+        }
         char bytes[8192], *endptr = token;
         size_t nn = 0;
         while (nn < sizeof(bytes)) {
@@ -404,6 +408,10 @@ int spi_commands(SPIDriver *sd, int argc, char *argv[])
     case 'r':
       {
         token = argv[++i];
+        if (token == NULL) {
+          fprintf(stderr, "Expected a number of bytes to read\n");
+          return 1;
+        }
         size_t nn = strtol(token, NULL, 0);
         char bytes[8192];
         spi_read(sd, bytes, nn);
@@ -416,20 +424,29 @@ int spi_commands(SPIDriver *sd, int argc, char *argv[])
 
     case 'a':
       token = argv[++i];
-      if (token != NULL)
-        spi_seta(sd, token[0]);
+      if (token == NULL) {
+        fprintf(stderr, "Expected value for A line\n");
+        return 1;
+      }
+      spi_seta(sd, token[0]);
       break;
 
     case 'b':
       token = argv[++i];
-      if (token != NULL)
-        spi_setb(sd, token[0]);
+      if (token == NULL) {
+        fprintf(stderr, "Expected value for B line\n");
+        return 1;
+      }
+      spi_setb(sd, token[0]);
       break;
 
     case 'm':
       token = argv[++i];
-      if (token != NULL)
-        spi_setmode(sd, token[0]);
+      if (token == NULL) {
+        fprintf(stderr, "Expected value for mode\n");
+        return 1;
+      }
+      spi_setmode(sd, token[0]);
       break;
 
     default:


### PR DESCRIPTION
For 'w' and 'r', a missing argument would cause a segfault. For 'a',
'b' and 'm', the command would just be ignored. Lets try to improve that
a little.