### PR TITLE
Fix warnings generated when building with verbose warnings

### DIFF
--- a/c/common/spidriver.c
+++ b/c/common/spidriver.c
@@ -149,7 +149,7 @@ int openSerialPort(const char *portname)
 
 size_t readFromSerialPort(int fd, char *b, size_t s)
 {
-  ssize_t n, t;
+  size_t n, t;
   t = 0;
   while (t < s) {
     n = read(fd, b + t, s);
@@ -168,7 +168,7 @@ size_t readFromSerialPort(int fd, char *b, size_t s)
 
 void writeToSerialPort(int fd, const char *b, size_t s)
 {
-  write(fd, b, s);
+  size_t  _ __attribute__((unused)) = write(fd, b, s);
 #ifdef VERBOSE
   printf("WRITE %u: ", (int)s);
   int i;
@@ -268,7 +268,7 @@ void spi_getstatus(SPIDriver *sd)
   bytesRead = readFromSerialPort(sd->port, readbuffer, 80);
   readbuffer[bytesRead] = 0;
   // printf("%d Bytes were read: %.*s\n", bytesRead, bytesRead, readbuffer);
-  sscanf(readbuffer, "[%15s %8s %" SCNu64 " %f %f %f %d %d %d %x ]",
+  sscanf(readbuffer, "[%15s %8s %" SCNu64 " %f %f %f %u %u %u %x ]",
     sd->model,
     sd->serial,
     &sd->uptime,

--- a/python/samples/gui.py
+++ b/python/samples/gui.py
@@ -9,7 +9,7 @@ import struct
 
 from spidriver import SPIDriver
 
-def ison(button): return button.get_state() == Gtk.StateType.ACTIVE
+def ison(button): return (button.get_state_flags() & Gtk.StateFlags.CHECKED) != 0
 def ishex(s): return re.match("[0-9a-fA-F]{2}$", s) is not None
 
 class SPIDriverWindow(Gtk.Window):

--- a/python/samples/gui.py
+++ b/python/samples/gui.py
@@ -42,13 +42,13 @@ class SPIDriverWindow(Gtk.Window):
             return r
 
         def checkbutton(name, state, click):
-            r = Gtk.CheckButton(name)
+            r = Gtk.CheckButton(label=name)
             r.set_active(state)
             r.connect("clicked", click)
             return r
 
         def button(name, click):
-            r = Gtk.Button(name)
+            r = Gtk.Button(label=name)
             r.connect("clicked", click)
             return r
 


### PR DESCRIPTION
Fix an unused variable warning and some warnings related to incorrect (signed/unsigned) sscanf format specifiers.
