### PR TITLE
Update st7735s.py

### DIFF
--- a/python/samples/st7735s.py
+++ b/python/samples/st7735s.py
@@ -17,7 +17,8 @@ def as565(im):
     d565 = [(s(b, 5) << 11) | (s(g, 6) << 5) | s(r, 5) for (r,g,b) in zip(rr, gg, bb)]
     d565h = array.array('H', d565)
     d565h.byteswap()
-    return array.array('B', d565h.tostring())
+    #tostring method is deprecated
+    return array.array('B', d565h.tobytes())
 
 NOP = 0x00
 SWRESET = 0x01


### PR DESCRIPTION
Replace the `array.array('B', d565h.tostring())`  with `array.array('B', d565h.tobytes())` to match deprecation in Python3.

Thanks for the great work!